### PR TITLE
 Make DSL lambda blocks more friendly for gradle.kts scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 plugins {
     id 'maven-publish'
     id 'java-gradle-plugin'
-    id 'org.jetbrains.kotlin.jvm' version "1.3.40-eap-105"
+    id 'org.jetbrains.kotlin.jvm' version "1.3.41"
 }
 
 // Load `local.properties` file, if it exists. You can put your bintrayUser and bintrayApiKey values there, that file is ignored by git

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,6 @@ bintrayRepository=maven
 # Put name of your package here.
 bintrayPackage=kotlinx.team.infra
         
-kotlin_version=1.3.40-eap-105
+kotlin_version=1.3.41
 jmhVersion=1.21
 

--- a/main/src/kotlinx/team/infra/InfraExtension.kt
+++ b/main/src/kotlinx/team/infra/InfraExtension.kt
@@ -1,9 +1,7 @@
 package kotlinx.team.infra
 
-import groovy.lang.*
 import kotlinx.team.infra.api.*
 import org.gradle.api.*
-import org.gradle.util.*
 
 open class InfraExtension(val project: Project) {
     val publishing = PublishingConfiguration()
@@ -12,19 +10,19 @@ open class InfraExtension(val project: Project) {
         publishingHandler = handler
     }
 
-    fun publishing(configureClosure: Closure<PublishingConfiguration>) {
-        ConfigureUtil.configureSelf(configureClosure, publishing)
+    fun publishing(configure: Action<PublishingConfiguration>) {
+        configure.execute(publishing)
         publishingHandler?.invoke(publishing)
-    }    
-    
+    }
+
     val teamcity = TeamCityConfiguration()
     private var teamcityHandler: ((TeamCityConfiguration) -> Unit)? = null
     internal fun afterTeamCity(handler: (TeamCityConfiguration) -> Unit) {
         teamcityHandler = handler
     }
 
-    fun teamcity(configureClosure: Closure<TeamCityConfiguration>) {
-        ConfigureUtil.configureSelf(configureClosure, teamcity)
+    fun teamcity(configure: Action<TeamCityConfiguration>) {
+        configure.execute(teamcity)
         teamcityHandler?.invoke(teamcity)
     }
 
@@ -34,8 +32,8 @@ open class InfraExtension(val project: Project) {
         apiCheckHandler = handler
     }
 
-    fun apiCheck(configureClosure: Closure<ApiCheckConfiguration>) {
-        ConfigureUtil.configureSelf(configureClosure, apiCheck)
+    fun apiCheck(configure: Action<ApiCheckConfiguration>) {
+        configure.execute(apiCheck)
         apiCheckHandler?.invoke(apiCheck)
     }
 }

--- a/main/src/kotlinx/team/infra/Publishing.kt
+++ b/main/src/kotlinx/team/infra/Publishing.kt
@@ -15,11 +15,18 @@ import java.util.*
 
 open class PublishingConfiguration {
     val bintray = BintrayConfiguration()
+    fun bintray(configure: Action<BintrayConfiguration>) {
+        configure.execute(bintray)
+    }
     fun bintray(configureClosure: Closure<BintrayConfiguration>) {
         ConfigureUtil.configureSelf(configureClosure, bintray)
     }
 
     var bintrayDev: BintrayConfiguration? = null
+    fun bintrayDev(configure: Action<BintrayConfiguration>) {
+        if (bintrayDev == null) bintrayDev = BintrayConfiguration()
+        configure.execute(bintrayDev)
+    }
     fun bintrayDev(configureClosure: Closure<BintrayConfiguration>) {
         if (bintrayDev == null) bintrayDev = BintrayConfiguration()
         ConfigureUtil.configureSelf(configureClosure, bintrayDev)


### PR DESCRIPTION
First level DSL blocks can be covered with a single method taking `Action<T>`, that will work idiomatically both in Groovy and in Kotlin scripts

For nested DSL blocks both overloads, one with groovy `Closure<T>`, one with `Action<T>`, have to be provided.

Based on recommendations from here: https://guides.gradle.org/implementing-gradle-plugins/#modeling_dsl_like_apis