### PR TITLE
Provide an option to not override TeamCity buildNumber

### DIFF
--- a/main/src/kotlinx/team/infra/InfraPlugin.kt
+++ b/main/src/kotlinx/team/infra/InfraPlugin.kt
@@ -29,8 +29,8 @@ class InfraPlugin : Plugin<Project> {
         configureTeamCityLogging()
         configureTeamCityConfigGenerator(extension.teamcity, extension.publishing)
 
-        extension.afterTeamCity {
-            configureTeamcityBuildNumber(it)
+        afterEvaluate {
+            configureTeamcityBuildNumber(extension.teamcity)
         }
         extension.afterPublishing {
             configurePublishing(it)

--- a/main/src/kotlinx/team/infra/InfraPlugin.kt
+++ b/main/src/kotlinx/team/infra/InfraPlugin.kt
@@ -29,6 +29,9 @@ class InfraPlugin : Plugin<Project> {
         configureTeamCityLogging()
         configureTeamCityConfigGenerator(extension.teamcity, extension.publishing)
 
+        extension.afterTeamCity {
+            configureTeamcityBuildNumber(it)
+        }
         extension.afterPublishing {
             configurePublishing(it)
         }

--- a/main/src/kotlinx/team/infra/TeamCity.kt
+++ b/main/src/kotlinx/team/infra/TeamCity.kt
@@ -9,6 +9,12 @@ open class TeamCityConfiguration {
 
     var jdk = "JDK_18_x64"
 
+    /**
+     * Specifies whether to override the build number in TeamCity, `true` by default.
+     *
+     * If `true`, the TeamCity build number will be changed to `"${project.version} (%build.counter%)"`.
+     * This value is overridden by `overrideTeamCityBuildNumber` gradle property when provided.
+     */
     var overrideBuildNumber = true
 }
 
@@ -21,7 +27,9 @@ fun Project.configureTeamCityLogging() {
 }
 
 fun Project.configureTeamcityBuildNumber(teamcity: TeamCityConfiguration) {
-    if (project.hasProperty("teamcity") && teamcity.overrideBuildNumber) {
+    val overrideTeamCityBuildNumber = project.findProperty("overrideTeamCityBuildNumber")?.toString()?.toBoolean()
+        ?: teamcity.overrideBuildNumber
+    if (project.hasProperty("teamcity") && overrideTeamCityBuildNumber) {
         // Tell teamcity about version number
         val teamcitySuffix = project.findProperty("teamcitySuffix")?.toString()
         println("##teamcity[buildNumber '${project.version}${teamcitySuffix?.let { " ($it)" } ?: ""}']")

--- a/main/src/kotlinx/team/infra/TeamCity.kt
+++ b/main/src/kotlinx/team/infra/TeamCity.kt
@@ -8,17 +8,23 @@ open class TeamCityConfiguration {
     var libraryStagingRepoDescription: String? = null
 
     var jdk = "JDK_18_x64"
+
+    var overrideBuildNumber = true
 }
 
 fun Project.configureTeamCityLogging() {
-    val teamcitySuffix = project.findProperty("teamcitySuffix")?.toString()
     if (project.hasProperty("teamcity")) {
-        // Tell teamcity about version number
-        println("##teamcity[buildNumber '${project.version}${teamcitySuffix?.let { " ($it)" } ?: ""}']")
-
         gradle.taskGraph.beforeTask {
             println("##teamcity[progressMessage 'Gradle: ${this.project.path}:${this.name}']")
         }
+    }
+}
+
+fun Project.configureTeamcityBuildNumber(teamcity: TeamCityConfiguration) {
+    if (project.hasProperty("teamcity") && teamcity.overrideBuildNumber) {
+        // Tell teamcity about version number
+        val teamcitySuffix = project.findProperty("teamcitySuffix")?.toString()
+        println("##teamcity[buildNumber '${project.version}${teamcitySuffix?.let { " ($it)" } ?: ""}']")
     }
 }
 


### PR DESCRIPTION
It was needed for `kotlinx-benchmark`. In UserProjects, where that library is included, infra overrides the buildNumberPattern set in the build configuration.