### PR TITLE
Configure signing of publishing projects regardless of sonatype

### DIFF
--- a/main/src/kotlinx/team/infra/Publishing.kt
+++ b/main/src/kotlinx/team/infra/Publishing.kt
@@ -95,8 +95,10 @@ internal fun Project.configurePublishing(publishing: PublishingConfiguration) {
         }
     }
 
-    includeProjects.forEach { subproject ->
-        subproject.configureSigning()
+    if (project.hasProperty("teamcity")) {
+        includeProjects.forEach { subproject ->
+            subproject.configureSigning()
+        }
     }
 
     gradle.includedBuilds.forEach { includedBuild ->

--- a/main/src/kotlinx/team/infra/Publishing.kt
+++ b/main/src/kotlinx/team/infra/Publishing.kt
@@ -91,9 +91,12 @@ internal fun Project.configurePublishing(publishing: PublishingConfiguration) {
         if (verifySonatypeConfiguration()) {
             includeProjects.forEach { subproject ->
                 subproject.createSonatypeRepository()
-                subproject.configureSigning()
             }
         }
+    }
+
+    includeProjects.forEach { subproject ->
+        subproject.configureSigning()
     }
 
     gradle.includedBuilds.forEach { includedBuild ->

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,7 +1,7 @@
 project.version = project.hasProperty('releaseVersion') ? project.property('releaseVersion') : project.version
 
 task sourceJar(type: Jar) {
-    classifier 'sources'
+    archiveClassifier.set("sources")
     from sourceSets.main.allJava.sourceDirectories
 }
 


### PR DESCRIPTION
It is needed when a plugin publishing is configured using infra.
The plugin might be published only to Gradle Plugin Portal.