### PR TITLE
Provide a Gradle property for using NativeBuildInfraExtension in IDEA

### DIFF
--- a/main/src/kotlinx/team/infra/NativeMultiplatform.kt
+++ b/main/src/kotlinx/team/infra/NativeMultiplatform.kt
@@ -27,7 +27,8 @@ fun Project.configureNativeMultiplatform() {
                 return@withPlugin
             }
 
-            val extension: Any = if (ideaActive)
+            val useNativeBuildInfraInIdea = subproject.findProperty("useNativeBuildInfraInIdea")?.toString()?.toBoolean() ?: false
+            val extension: Any = if (ideaActive && !useNativeBuildInfraInIdea)
                 NativeIdeaInfraExtension(subproject, kotlin, "native")
             else
                 NativeBuildInfraExtension(subproject, kotlin, "native")


### PR DESCRIPTION
It is useful for Kotlin Compiler QAs to be able to target all native targets supported by the project depending on the plugin when using kotlinx libraries as Kotlin user projects for local testing of development builds of the Kotlin compiler.