### PR TITLE
Settings generator: update tc config version

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -26,7 +26,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 
 version = "2020.1"
 val versionParameter = "releaseVersion"
-val publishVersion = "0.3.0"
+val publishVersion = "0.4.0"
 
 project {
     // Disable editing of project and build settings from the UI to avoid issues with TeamCity

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 # Set up your maven coordinates here, artifactId is defined per project.
-version = 0.3.0
+version = 0.4.0
 group = kotlinx.team
 
 kotlin_version=1.5.0

--- a/main/resources/teamcity/additionalConfiguration.kt
+++ b/main/resources/teamcity/additionalConfiguration.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
-import jetbrains.buildServer.configs.kotlin.v2019_2.Project
+import jetbrains.buildServer.configs.kotlin.Project
 
 fun Project.additionalConfiguration() {
 }

--- a/main/resources/teamcity/pom.xml
+++ b/main/resources/teamcity/pom.xml
@@ -77,13 +77,13 @@
   <dependencies>
     <dependency>
       <groupId>org.jetbrains.teamcity</groupId>
-      <artifactId>configs-dsl-kotlin</artifactId>
+      <artifactId>configs-dsl-kotlin-latest</artifactId>
       <version>${teamcity.dsl.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.teamcity</groupId>
-      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <artifactId>configs-dsl-kotlin-plugins-latest</artifactId>
       <version>1.0-SNAPSHOT</version>
       <type>pom</type>
       <scope>compile</scope>

--- a/main/resources/teamcity/settings.kts
+++ b/main/resources/teamcity/settings.kts
@@ -1,6 +1,6 @@
-import jetbrains.buildServer.configs.kotlin.v2019_2.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.*
-import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.*
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.*
+import jetbrains.buildServer.configs.kotlin.triggers.*
 
 /*
 The settings script is an entry point for defining a TeamCity
@@ -24,7 +24,7 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 'Debug' option is available in the context menu for the task.
 */
 
-version = "2020.1"
+version = "2023.05"
 
 project {
     // Disable editing of project and build settings from the UI to avoid issues with TeamCity

--- a/main/resources/teamcity/utils.kt
+++ b/main/resources/teamcity/utils.kt
@@ -3,7 +3,7 @@
  * Use of this source code is governed by the Apache 2.0 License that can be found in the LICENSE.txt file.
  */
 
-import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.*
 
 const val versionSuffixParameter = "versionSuffix"
 const val teamcitySuffixParameter = "teamcitySuffix"


### PR DESCRIPTION
Settings updated according to recommendations: https://www.jetbrains.com/help/teamcity/2023.05/upgrading-dsl.html#packages-without-dsl-api-version

Tested on kotlinx-datetime, produced xml settings are identical

Temporarily available for testing as 0.3.0-dev-79-test version.

Version bump is required to 0.4.0 because it requires manual import changes after settings regeneration in `additionalConfiguration.kt`