### PR TITLE
Fix publishToBuildLocal task dependency declaration

### DIFF
--- a/main/src/kotlinx/team/infra/Publishing.kt
+++ b/main/src/kotlinx/team/infra/Publishing.kt
@@ -145,7 +145,7 @@ private fun Project.createBuildRepository(name: String, rootBuildLocal: Task) {
                 delete(dir)
             }
 
-            tasks.withType(PublishToMavenRepository::class.java).configureEach {
+            tasks.withType(PublishToMavenRepository::class.java) {
                 if (this.repository == repo) {
                     compositeTask.dependsOn(this)
                 }

--- a/main/src/kotlinx/team/infra/Publishing.kt
+++ b/main/src/kotlinx/team/infra/Publishing.kt
@@ -145,11 +145,9 @@ private fun Project.createBuildRepository(name: String, rootBuildLocal: Task) {
                 delete(dir)
             }
 
-            tasks.withType(PublishToMavenRepository::class.java) {
-                if (this.repository == repo) {
-                    compositeTask.dependsOn(this)
-                }
-            }
+            compositeTask.dependsOn(
+                tasks.withType(PublishToMavenRepository::class.java).matching { it.repository == repo }
+            )
         }
     }
 }


### PR DESCRIPTION
The changes introduced in https://github.com/Kotlin/kotlinx.team.infra/commit/3c82699b7aeb8851af5386fad0123295fc87779e seem to break dependency declaration for the `publishToBuildLocal` task. Thus, running the task does nothing. This MR reverts the affecting change.