### PR TITLE
Don't apply signing plugin if signing is not configured

### DIFF
--- a/main/src/kotlinx/team/infra/Publishing.kt
+++ b/main/src/kotlinx/team/infra/Publishing.kt
@@ -258,12 +258,12 @@ private fun MavenPublication.configureRequiredPomAttributes(project: Project, pu
 }
 
 private fun Project.configureSigning() {
-    project.pluginManager.apply(SigningPlugin::class.java)
     val keyId = project.propertyOrEnv("libs.sign.key.id")
     val signingKey = project.propertyOrEnv("libs.sign.key.private")
     val signingKeyPassphrase = project.propertyOrEnv("libs.sign.passphrase")
 
     if (keyId != null) {
+        project.pluginManager.apply(SigningPlugin::class.java)
         project.extensions.configure<SigningExtension>("signing") {
             useInMemoryPgpKeys(keyId, signingKey, signingKeyPassphrase)
             val signingTasks = sign(extensions.getByType(PublishingExtension::class.java).publications) // all publications


### PR DESCRIPTION
Currently, we're always applying the signing plugin (when configuring signing), but then, if the PGP key is unknown, we abstain from further configuration.

Such an approach works fine, until it doesn't: Gradle "plugin publish" plugin setup signing (and creates sign-task) if the signing plugin was applied to a project, and then the task fails due to missing credentials.

This change postpones signing plugin application until we're sure that credentials were provided.